### PR TITLE
Update wabt reference test suite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,15 +18,15 @@ members = ['fuzz']
 
 [dependencies]
 anyhow = "1.0"
-wasmparser = "0.45.0"
+wasmparser = "0.47.0"
 
 [dev-dependencies]
 diff = "0.1"
 getopts = "0.2"
 rayon = "1.0"
 tempfile = "3.0"
-wast = "4.0.0"
-wat = "1.0.4"
+wast = "6.0.0"
+wat = "1.0.7"
 
 [[test]]
 name = "wabt"


### PR DESCRIPTION
A few more exceptions added, included `wasmparser` updates to parse new
passive segments, and a few other minor tweaks.